### PR TITLE
Add support for XF86Audio multimedia buttons

### DIFF
--- a/korgwm.conf.sample
+++ b/korgwm.conf.sample
@@ -1,4 +1,4 @@
-# Default configuration is as follows.
+# Sample configuration is as follows.
 # korgwm tries to find the config in such an order:
 #   /etc/korgwm/korgwm.conf
 #   /usr/local/etc/korgwm/korgwm.conf
@@ -101,11 +101,15 @@ color_urgent_fg: 0x464729
 
 ## Hotkeys, see API.pm for description of possible functions
 hotkeys:
-  XF86AudioLowerVolume: 'nop()'
-  XF86AudioMute: 'nop()'
-  XF86AudioRaiseVolume: 'nop()'
-  XF86MonBrightnessDown: 'nop()'
-  XF86MonBrightnessUp: 'nop()'
+  XF86AudioLowerVolume: 'exec(pactl set-sink-volume 0 -10%)'
+  XF86AudioMute: 'exec(pactl set-sink-mute 0 toggle)'
+  XF86AudioRaiseVolume: 'exec(pactl set-sink-volume 0 +10%)'
+  XF86MonBrightnessDown: 'exec(light -U 20)'
+  XF86MonBrightnessUp: 'exec(light -A 20)'
+  XF86AudioPlay: 'exec(playerctl play-pause)'
+  XF86AudioStop: 'exec(playerctl stop)'
+  XF86AudioPrev: 'exec(playerctl previous)'
+  XF86AudioNext: 'exec(playerctl next)'
   XF86WakeUp: 'nop()'
   Print: 'exec(flameshot gui)'
   alt_F4: 'win_close()'

--- a/lib/X11/korgwm/Hotkeys.pm
+++ b/lib/X11/korgwm/Hotkeys.pm
@@ -22,6 +22,10 @@ my $keys = {
     "XF86AudioLowerVolume"  => 0x1008FF11,
     "XF86AudioMute"         => 0x1008FF12,
     "XF86AudioRaiseVolume"  => 0x1008FF13,
+    "XF86AudioPlay"         => 0x1008FF14,
+    "XF86AudioStop"         => 0x1008FF15,
+    "XF86AudioPrev"         => 0x1008FF16,
+    "XF86AudioNext"         => 0x1008FF17,
     "XF86WakeUp"            => 0x1008FF2B,
 };
 


### PR DESCRIPTION
Add Play, Stop, Prev and Next codes from `X11/XF86keysym.h`
Update conf.sample with examples of usage (via playerctl)
![image](https://github.com/user-attachments/assets/8273d58f-07f1-47e9-99ed-50cc9f5d7088)
